### PR TITLE
Allow skipping on noarch package from the command line

### DIFF
--- a/conda_build_all/builder.py
+++ b/conda_build_all/builder.py
@@ -130,7 +130,7 @@ class Builder(object):
                  inspection_channels, inspection_directories,
                  artefact_destinations,
                  matrix_conditions, matrix_max_n_major_minor_versions=(2, 2),
-                 dry_run=False):
+                 dry_run=False, skip_noarch=False):
         """
         Build a directory of conda recipes sequentially, if they don't already exist in the inspection locations.
 
@@ -153,6 +153,8 @@ class Builder(object):
         dry_run : bool
             True to stop before building recipes but after determining which
             recipes to build.
+        skip_noarch : bool
+            True to skip noarch packages.
 
         """
         self.conda_recipes_directory = conda_recipes_directory
@@ -162,6 +164,7 @@ class Builder(object):
         self.matrix_conditions = matrix_conditions
         self.matrix_max_n_major_minor_versions = matrix_max_n_major_minor_versions
         self.dry_run = dry_run
+        self.skip_noarch = skip_noarch
 
     def fetch_all_metas(self, config):
         """
@@ -225,6 +228,8 @@ class Builder(object):
         except ImportError:
             index = index.copy()
         for meta in recipes:
+            if self.skip_noarch and meta.noarch:
+                continue
             distros = resolved_distribution.ResolvedDistribution.resolve_all(meta, index,
                                                                              self.matrix_conditions)
             cases = [distro.special_versions for distro in distros]

--- a/conda_build_all/cli.py
+++ b/conda_build_all/cli.py
@@ -28,6 +28,9 @@ def main():
     parser.add_argument('--no-inspect-conda-bld-directory', default=False,
         action='store_true',
         help='Do not add the conda-build directory to the inspection list.')
+    parser.add_argument('--dry-run', default=False,
+        action='store_true',
+        help='Skip all builds, just list what distribution would be built.')
 
     parser.add_argument('--artefact-directory',
         help='A directory for any newly built distributions to be placed.')
@@ -86,7 +89,7 @@ def main():
                                         inspection_directories,
                                         artefact_destinations,
                                         args.matrix_conditions,
-                                        max_n_versions)
+                                        max_n_versions, args.dry_run)
     b.main()
 
 

--- a/conda_build_all/cli.py
+++ b/conda_build_all/cli.py
@@ -31,6 +31,8 @@ def main():
     parser.add_argument('--dry-run', default=False,
         action='store_true',
         help='Skip all builds, just list what distribution would be built.')
+    parser.add_argument('--skip-noarch', default=False, action='store_true',
+        help='Do not build noarch packages')
 
     parser.add_argument('--artefact-directory',
         help='A directory for any newly built distributions to be placed.')
@@ -89,7 +91,8 @@ def main():
                                         inspection_directories,
                                         artefact_destinations,
                                         args.matrix_conditions,
-                                        max_n_versions, args.dry_run)
+                                        max_n_versions,
+                                        args.dry_run, args.skip_noarch)
     b.main()
 
 

--- a/conda_build_all/tests/unit/dummy_index.py
+++ b/conda_build_all/tests/unit/dummy_index.py
@@ -14,13 +14,13 @@ import conda.config
 
 _DummyPackage = collections.namedtuple('_DummyPackage',
                                        ['pkg_name', 'build_deps',
-                                        'run_deps', 'vn', 'noarch'])
+                                        'run_deps', 'vn'])
 
 
 class DummyPackage(_DummyPackage):
-    def __new__(cls, name, build_deps=None, run_deps=None, version='0.0', noarch=''):
+    def __new__(cls, name, build_deps=None, run_deps=None, version='0.0'):
         return super(DummyPackage, cls).__new__(cls, name, build_deps or (),
-                                                run_deps or (), version, noarch)
+                                                run_deps or (), version)
 
     def name(self):
         return self.pkg_name

--- a/conda_build_all/tests/unit/dummy_index.py
+++ b/conda_build_all/tests/unit/dummy_index.py
@@ -14,13 +14,13 @@ import conda.config
 
 _DummyPackage = collections.namedtuple('_DummyPackage',
                                        ['pkg_name', 'build_deps',
-                                        'run_deps', 'vn'])
+                                        'run_deps', 'vn', 'noarch'])
 
 
 class DummyPackage(_DummyPackage):
-    def __new__(cls, name, build_deps=None, run_deps=None, version='0.0'):
+    def __new__(cls, name, build_deps=None, run_deps=None, version='0.0', noarch=''):
         return super(DummyPackage, cls).__new__(cls, name, build_deps or (),
-                                                run_deps or (), version)
+                                                run_deps or (), version, noarch)
 
     def name(self):
         return self.pkg_name

--- a/conda_build_all/tests/unit/test_version_matrix.py
+++ b/conda_build_all/tests/unit/test_version_matrix.py
@@ -45,6 +45,14 @@ class Test_special_case_version_matrix(unittest.TestCase):
                                 ))
                          )
 
+    def test_noarch_python(self):
+        a = DummyPackage('pkgA', ['python'])
+        a.noarch = 'python'
+        self.index.add_pkg('python', '2.7.2')
+        self.index.add_pkg('python', '3.5.0')
+        r = special_case_version_matrix(a, self.index)
+        self.assertEqual(r, set(((), )))
+
     def test_constrained_python(self):
         a = DummyPackage('pkgA', ['python <3'])
         self.index.add_pkg('python', '2.7.2')

--- a/conda_build_all/version_matrix.py
+++ b/conda_build_all/version_matrix.py
@@ -227,7 +227,7 @@ def special_case_version_matrix(meta, index):
                             )
                     add_case_if_soluble(case)
         elif 'python' in requirement_specs:
-            if meta.noarch == 'python':
+            if getattr(meta, 'noarch', None) == 'python':
                 # no python version dependency on noarch: python recipes
                 add_case_if_soluble(())
             else:

--- a/conda_build_all/version_matrix.py
+++ b/conda_build_all/version_matrix.py
@@ -227,11 +227,15 @@ def special_case_version_matrix(meta, index):
                             )
                     add_case_if_soluble(case)
         elif 'python' in requirement_specs:
-            py_spec = requirement_specs.pop('python')
-            for python_pkg in get_pkgs(py_spec):
-                py_vn = minor_vn(index[get_key(python_pkg)]['version'])
-                case = (('python', py_vn), )
-                add_case_if_soluble(case)
+            if meta.noarch == 'python':
+                # no python version dependency on noarch: python recipes
+                add_case_if_soluble(())
+            else:
+                py_spec = requirement_specs.pop('python')
+                for python_pkg in get_pkgs(py_spec):
+                    py_vn = minor_vn(index[get_key(python_pkg)]['version'])
+                    case = (('python', py_vn), )
+                    add_case_if_soluble(case)
 
         if 'perl' in requirement_specs:
             pl_spec = requirement_specs.pop('perl')


### PR DESCRIPTION
* The building on noarch packages can be controlled from the command line using the `--skip-noarch` argument.
* Only a single build will be done for `noarch: python` recipes.
* Add a `--dry-run` argument to allow builds to be viewed without execution.