### PR TITLE
WIP: Handles `noarch_python: true` and `noarch: python`

### DIFF
--- a/conda_build_all/tests/integration/test_builder.py
+++ b/conda_build_all/tests/integration/test_builder.py
@@ -62,6 +62,52 @@ class Test_build(RecipeCreatingUnit):
         self.assertEqual(os.path.abspath(r), r)
         self.assertEqual(os.path.basename(r), 'pkg1-1.0-0.tar.bz2')
 
+    def test_noarch_python_legacy(self):
+        pkg1 = self.write_meta('pkg1', """
+                    package:
+                        name: pkg1
+                        version: 1.0
+                    build:
+                        noarch_python: true
+                    requirements:
+                        build:
+                            - python
+                        run:
+                            - python
+                    """)
+        pkg1_resolved = ResolvedDistribution(pkg1, (['python', '3.5']))
+        builder = Builder(None, None, None, None, None)
+        if hasattr(conda_build, 'api'):
+            r = builder.build(pkg1_resolved, conda_build.api.Config())
+        else:
+            r = builder.build(pkg1_resolved, conda_build.config.config)
+        self.assertTrue(os.path.exists(r))
+        self.assertEqual(os.path.abspath(r), r)
+        self.assertEqual(os.path.basename(r), 'pkg1-1.0-py_0.tar.bz2')
+
+    def test_noarch_python(self):
+        pkg1 = self.write_meta('pkg1', """
+                    package:
+                        name: pkg1
+                        version: 1.0
+                    build:
+                        noarch: python
+                    requirements:
+                        build:
+                            - python
+                        run:
+                            - python
+                    """)
+        pkg1_resolved = ResolvedDistribution(pkg1, (['python', '3.5']))
+        builder = Builder(None, None, None, None, None)
+        if hasattr(conda_build, 'api'):
+            r = builder.build(pkg1_resolved, conda_build.api.Config())
+        else:
+            r = builder.build(pkg1_resolved, conda_build.config.config)
+        self.assertTrue(os.path.exists(r))
+        self.assertEqual(os.path.abspath(r), r)
+        self.assertEqual(os.path.basename(r), 'pkg1-1.0-py_0.tar.bz2')
+
     def test_numpy_dep(self):
         pkg1 = self.write_meta('pkg1', """
                     package:

--- a/conda_build_all/tests/unit/dummy_index.py
+++ b/conda_build_all/tests/unit/dummy_index.py
@@ -14,13 +14,16 @@ import conda.config
 
 _DummyPackage = collections.namedtuple('_DummyPackage',
                                        ['pkg_name', 'build_deps',
-                                        'run_deps', 'vn'])
+                                        'run_deps', 'vn', 'noarch',
+                                        'noarch_py'])
 
 
 class DummyPackage(_DummyPackage):
-    def __new__(cls, name, build_deps=None, run_deps=None, version='0.0'):
+    def __new__(cls, name, build_deps=None, run_deps=None, version='0.0',
+                noarch='', noarch_py=False):
         return super(DummyPackage, cls).__new__(cls, name, build_deps or (),
-                                                run_deps or (), version)
+                                                run_deps or (), version,
+                                                noarch, noarch_py)
 
     def name(self):
         return self.pkg_name
@@ -32,7 +35,11 @@ class DummyPackage(_DummyPackage):
         return '{}-{}-{}'.format(self.name(), self.version(), '0')
 
     def get_value(self, item, default):
-        if item == 'requirements/run':
+        if item == 'build/noarch':
+            return self.noarch
+        elif item == 'build/noarch_python':
+            return self.noarch_py
+        elif item == 'requirements/run':
             return self.run_deps
         elif item == 'requirements/build':
             return self.build_deps

--- a/conda_build_all/version_matrix.py
+++ b/conda_build_all/version_matrix.py
@@ -372,7 +372,13 @@ def keep_top_n_minor_versions(cases, n=2):
 
 if hasattr(conda_build, 'api'):
     def setup_vn_mtx_case(case, config):
-        for pkg, version in case:
+        for each_case in case:
+            # If the special case is an empty tuple, continue.
+            # Could happen if a Python noarch package is built.
+            if not each_case:
+                continue
+
+            pkg, version = each_case
             if pkg == 'python':
                 version = int(version.replace('.', ''))
                 config.CONDA_PY = version
@@ -396,7 +402,12 @@ else:
         orig_py = conda_build.config.config.CONDA_PY
         orig_r = conda_build.config.config.CONDA_R
         orig_perl = conda_build.config.config.CONDA_PERL
-        for pkg, version in case:
+        for each_case in case:
+            # If the special case is an empty tuple, continue.
+            # Could happen if a Python noarch package is built.
+            if not each_case:
+                continue
+
             if pkg == 'python':
                 version = int(version.replace('.', ''))
                 config.CONDA_PY = version

--- a/conda_build_all/version_matrix.py
+++ b/conda_build_all/version_matrix.py
@@ -142,6 +142,17 @@ def special_case_version_matrix(meta, index):
     run_requirements = meta.get_value('requirements/run', [])
     run_requirement_specs = parse_specifications(run_requirements)
 
+    # Check to see if this is a noarch python package.
+    # Could be that `noarch_python` is set to True or
+    # that `noarch` is set to `"python"`.
+    py_spec = requirement_specs.get('python')
+    noarch_python = (meta.get_value('build/noarch_python', False) or
+                     (meta.get_value('build/noarch', '') == 'python'))
+    if py_spec and noarch_python:
+        # A simple spec (noarch python) has been defined, so we can drop it from the
+        # special cases.
+        requirement_specs.pop('python')
+
     # Thanks to https://github.com/conda/conda-build/pull/493 we no longer need to
     # compute the complex matrix for numpy versions unless a specific version has
     # been defined.


### PR DESCRIPTION
Support building `noarch` Python packages with `conda-build-all` in either the legacy format or the new one.

Note: Still needs some tests.