### PR TITLE
Add --dry-run argument

### DIFF
--- a/conda_build_all/cli.py
+++ b/conda_build_all/cli.py
@@ -28,6 +28,9 @@ def main():
     parser.add_argument('--no-inspect-conda-bld-directory', default=False,
         action='store_true',
         help='Do not add the conda-build directory to the inspection list.')
+    parser.add_argument('--dry-run', default=False,
+        action='store_true',
+        help='Skip all builds, just list what distribution would be built.')
 
     parser.add_argument('--artefact-directory',
         help='A directory for any newly built distributions to be placed.')
@@ -86,7 +89,7 @@ def main():
                                         inspection_directories,
                                         artefact_destinations,
                                         args.matrix_conditions,
-                                        max_n_versions)
+                                        max_n_versions, args.dry_run)
     b.main()
 
 


### PR DESCRIPTION
The --dry-run argument can be used to list what distributions would be built
without actually performing the builds.